### PR TITLE
Create 'registration-confirmation' page

### DIFF
--- a/app/views/registration-confirmation.html
+++ b/app/views/registration-confirmation.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %} {% block pageTitle %} Confirmation page template –
+{{ serviceName }} – GOV.UK Prototype Kit {% endblock %} {% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p>We have sent you a confirmation email.</p>
+    <h2 class="govuk-heading-m">What happens next</h2>
+    <p>You can log in again at any time via www.loginagain.com</p>
+    <p>
+      <a
+        href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html"
+        >What did you think of this service?</a
+      >
+      (takes 30 seconds)
+    </p>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Summary:
This is the page that should appear after users sign up after pressing the 'save progress' button.

<img width="1062" alt="Screenshot 2022-07-19 at 12 39 57" src="https://user-images.githubusercontent.com/64155953/179741929-01b5a6bb-18a9-4cda-b0bd-869fb66f1c9c.png">
