### PR TITLE
Create upload confirmation and link to page

### DIFF
--- a/app/views/upload-confirmation.html
+++ b/app/views/upload-confirmation.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %} {% block pageTitle %} Content page template – {{
+serviceName }} – GOV.UK Prototype Kit {% endblock %} {% block beforeContent %}
+<a class="govuk-back-link" href="javascript:window.history.back()">Back</a>
+{% endblock %} {% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">This is your upload</h1>
+    <div class="border">
+      <p>[Uploaded file goes here]</p>
+    </div>
+    <p>
+      <a class="" href="upload-your-document">Remove</a>
+    </p>
+
+    <br />
+    <br />
+    {% from "govuk/components/button/macro.njk" import govukButton %} {{
+    govukButton({ text: "Continue", href: "confirm-services-to-share" }) }}
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/upload-your-document.html
+++ b/app/views/upload-your-document.html
@@ -58,7 +58,7 @@ serviceName }} – GOV.UK Prototype Kit {% endblock %} {% block beforeContent %}
 
     {% from "govuk/components/button/macro.njk" import govukButton %} {{
     govukButton({ text: "Submit and continue", preventDoubleClick: true, href:
-    "#" }) }}
+    "upload-confirmation" }) }}
   </div>
 </div>
 


### PR DESCRIPTION
Users can see what they have uploaded and remove it (takes you back to upload page)
<img width="1473" alt="upload-confirmation" src="https://user-images.githubusercontent.com/17614754/179804620-fba16866-9393-4829-bcf3-47010ff034dc.png">

