### PR TITLE
split index page into two columns

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -8,28 +8,29 @@
 {% block content %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
-        Council Home screen
-        <!-- <span class="govuk-caption-xl">{{releaseVersion}}</span> -->
-      </h1>{{releaseVersion | log }}
-
+    <div class="govuk-grid-columnn-full">
+    <h1 class="govuk-heading-xl">
+      Council Home screen
+    </h1>
+    </div>
+    <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-m">Council Tax</h2>
       <p class="govuk-body">
-        Council Tax is a tax on council property.</p>
-
+        Council Tax is a tax on council property.
+      </p>
       <h2 class="govuk-heading-m">Benefits</h2>
       <p class="govuk-body">
-        Housing Benefit can help you pay your rent if you're unemployed, on a low income or claiming benefits. It's being replaced by Universal Credit.</p>
-
+        Housing Benefit can help you pay your rent if you're unemployed, on a low income or claiming benefits. It's being replaced by Universal Credit.
+      </p>
       <h2 class="govuk-heading-m">Blue badge application</h2>
       <p class="govuk-body">
-        Blue Badges help people with disabilities or health conditions park closer to their destination.</p>
-
+        Blue Badges help people with disabilities or health conditions park closer to their destination.
+      </p>
+      </div>
+    <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-m"><a href="/my-council-account">My council account</a></h2>
       <p class="govuk-body">
         Log in to your account or create a new one.</p>
-
       <h2 class="govuk-heading-m">Parking permit</h2>
       <p class="govuk-body">
         A permit will enable the holder to park in any vacant on-street resident parking permit holder's space, or if applicable, shared use space within the permits' zone of issue, between the hours displayed on signs. These are found at the entry points to the zone, or adjacent to some parking bays.</p>


### PR DESCRIPTION
I've split the first page into two columns as was originally prototyped:

![Screenshot 2022-07-21 at 14 16 19](https://user-images.githubusercontent.com/10667172/180230041-9707504c-aa64-4e7d-aeda-1f755e62982e.png)
